### PR TITLE
Fix #11 by setting 'explicitType' to string.

### DIFF
--- a/src/decorators/EntityFromParam.ts
+++ b/src/decorators/EntityFromParam.ts
@@ -17,6 +17,7 @@ export function EntityFromParam(paramName: string, options?: EntityParamOptions)
             index: index,
             name: paramName,
             type: "param",
+            explicitType: "string",
             parse: options && options.parse,
             required: options && options.required,
             transform: (actionProperties, value) => entityTransform(value, target, isArray, options)


### PR DESCRIPTION
Sets explicit type in EntityFromParam to string which fixes a routing-controllers ParameterParseJsonError when trying to parse a string parameter; fixing #11.